### PR TITLE
Ajout d'un define() pour le nombre de lignes retournées par les requêtes HAL

### DIFF
--- a/action/editer_hal.php
+++ b/action/editer_hal.php
@@ -2,6 +2,8 @@
 
 if (!defined("_ECRIRE_INC_VERSION")) return;
 
+define("_SPIP_HAL_API_ROWS", "100");
+
 function action_editer_hal_dist($arg=null) {
 
 	if (is_null($arg)){
@@ -84,7 +86,7 @@ function hal_modifier($id_hal, $set=false) {
 		$q .= 'authId_i:'.$c['authid'];
 	
 	$hal_api = parametre_url($hal_api,'q',$q);
-	$hal_api = parametre_url(parametre_url($hal_api,'sort','modifiedDate_s desc'),'rows','100');
+	$hal_api = parametre_url($hal_api,'sort','modifiedDate_s desc');
 
 	$c['url_syndic'] = $hal_api;
 	

--- a/genie/hal.php
+++ b/genie/hal.php
@@ -61,6 +61,7 @@ function hal_a_jour($now_id_hal) {
 	include_spip('inc/distant');
 
 	$url_syndic = parametre_url($url_syndic,'fl','*','&');
+	$url_syndic = parametre_url($url_syndic,'rows',_SPIP_HAL_API_ROWS,'&');
 
 	$json = recuperer_page($url_syndic, true);
 	if (!$json)


### PR DESCRIPTION
On ajoute un `define("_SPIP_HAL_API_ROWS")` permettant de paramétrer le nombre de lignes renvoyées. Ce paramètre est ajouté dynamiquement à chaque appel dans `hal.php`, et non uniquement lors de la création ou modification du dépôt.
