### PR TITLE
utiliser le pipeline afficher_complement_objet

### DIFF
--- a/hal_pipelines.php
+++ b/hal_pipelines.php
@@ -41,19 +41,13 @@ function hal_optimiser_base_disparus($flux){
 
 }
 
-function hal_afficher_complement_objet($flux){
-	if($flux['args']['type'] == "hal"){
+function hal_afficher_complement_objet($flux) {
+	if ($flux['args']['type'] == "hal") {
 		$contexte = array_merge($flux['args'],$_GET);
 		$flux['data'] .= recuperer_fond('prive/objets/liste/hals_publications',$contexte,array('ajax'=>true));
-	}
-	return $flux;
-}
-
-function hal_affiche_milieu($flux){
-	if($flux['args']['exec'] == "auteur"){
-		$contexte = array_merge(array('id_auteur'=>$flux['args']['id_auteur']),$_GET);
+	} else if ($flux['args']['type'] == "auteur") {
+		$contexte = array_merge(array('id_auteur'=>$flux['args']['id']),$_GET);
 		$flux['data'] .= recuperer_fond('prive/objets/liste/hals',$contexte,array('ajax'=>true));
 	}
 	return $flux;
 }
-

--- a/paquet.xml
+++ b/paquet.xml
@@ -1,7 +1,7 @@
 <paquet
 	prefix="hal"
 	categorie="edition"
-	version="0.4.1"
+	version="0.4.2"
 	etat="stable"
 	compatibilite="[3.0.0;3.1.*]"
 	logo="prive/themes/spip/images/hal-32.png"
@@ -21,7 +21,6 @@
 	<pipeline nom="taches_generales_cron" inclure="hal_pipelines.php" />
 	<pipeline nom="optimiser_base_disparus" inclure="hal_pipelines.php" />
 	<pipeline nom="afficher_complement_objet" inclure="hal_pipelines.php" />
-	<pipeline nom="affiche_milieu" inclure="hal_pipelines.php" />
 
 	<menu nom="hals" titre="hal:icone_hals_references" parent="menu_edition" icone="images/hal-16.png" />
 	<menu nom="hal_creer" titre="hal:icone_referencer_nouveau_hal" parent="outils_rapides" icone="images/hal-new-16.png" action="hal_edit" parametres="new=oui" />


### PR DESCRIPTION
pour insérer la liste des dépôts sur la page d'un auteur

sans quoi le bouton de la messagerie interne déborde sur la liste à cause d'un problème de float

autre solution, on pourrait passer par le même pipeline que la liste des articles de l'auteur, cf affiche_auteurs_interventions